### PR TITLE
Support `go1.20.14.exe run github.com/hymkor/make-scoop-manifest@latest`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,22 @@ else
     NUL=/dev/null
 endif
 
+ifndef GO
+    SUPPORTGO=go1.20.14
+    GO:=$(shell $(WHICH) $(SUPPORTGO) 2>$(NUL) || echo $(GO))
+endif
+
 NAME:=$(notdir $(CURDIR))
 VERSION:=$(shell git describe --tags 2>$(NUL) || echo v0.0.0)
 GOOPT:=-ldflags "-s -w -X main.version=$(VERSION)"
-EXE:=$(shell go env GOEXE)
+EXE:=$(shell $(GO) env GOEXE)
 
 all:
-	go fmt ./...
-	$(SET) "CGO_ENABLED=0" && go build $(GOOPT)
+	$(GO) fmt ./...
+	$(SET) "CGO_ENABLED=0" && $(GO) build $(GOOPT)
 
 _dist:
-	$(MAKE) all
+	$(SET) "CGO_ENABLED=0" && $(GO) build $(GOOPT)
 	zip $(NAME)-$(VERSION)-$(GOOS)-$(GOARCH).zip $(NAME)$(EXE)
 
 dist:
@@ -34,6 +39,6 @@ d-manifest:
 	make-scoop-manifest -D > $(NAME).json
 
 release:
-	gh release create -d --notes "" -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
+	$(GO) run github.com/hymkor/latest-notes@master | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
 .PHONY: all dist _dist manifest release clean-dist test

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"slices"
 	"sort"
 	"strings"
 
@@ -285,10 +284,17 @@ var (
 	rxRepositoryH = regexp.MustCompile(`^(?:https://github.com/)?([^/]+)/([^/]+)`)
 )
 
+func slicesInsert(s []string, at int, element string) []string {
+	s = append(s, "")
+	copy(s[at+1:], s[at:])
+	s[at] = element
+	return s
+}
+
 func mains(args []string) error {
 	// for compatiblity
 	if *flagUserAndRepo != "" {
-		args = slices.Insert(args, 0, *flagUserAndRepo)
+		args = slicesInsert(args, 0, *flagUserAndRepo)
 	}
 	localfiles := map[string]string{}
 	var owner, repos string

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -1,6 +1,10 @@
 Release notes (English)
 =======================
 
+- Support `go1.20.14.exe run github.com/hymkor/make-scoop-manifest@latest` (#4)
+  - Stop using "slices" package; support building with Go 1.20.14
+  - Makefile: Use go1.20.14(.exe) if available
+
 v0.11.0
 -------
 Nov 26, 2025

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -1,6 +1,10 @@
 Release notes (Japanese)
 ========================
 
+- `go1.20.14.exe run github.com/hymkor/make-scoop-manifest@latest` 方式の実行をサポート (#4)
+  - "slices" パッケージの使用をやめ、Go 1.20.14 でもビルドできるようにした
+  - Makefile: go1.20.14(.exe) があれば go1.20.14(.exe) を使用するようにした
+
 v0.11.0
 -------
 Nov 26, 2025


### PR DESCRIPTION
(English)
- Support `go1.20.14.exe run github.com/hymkor/make-scoop-manifest@latest`
  - Stop using "slices" package; support building with Go 1.20.14
  - Makefile: Use go1.20.14(.exe) if available

(Japanese)
- `go1.20.14.exe run github.com/hymkor/make-scoop-manifest@latest` 方式の実行をサポート
  - "slices" パッケージの使用をやめ、Go 1.20.14 でもビルドできるようにした
  - Makefile: go1.20.14(.exe) があれば go1.20.14(.exe) を使用するようにした